### PR TITLE
Improve the SitemapUrlProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ Usage:
 
 ## Sitemap Provider
 
-This bundle comes with URL provider that looks at a site's `sitemap.xml` to retrieve a list of urls.  The provider
-first looks for a `sitemap_index.xml` to find a set of sitemap files.  If no index is found, it defaults to using
-`sitemap.xml`.
+This bundle comes with a URL provider that looks at a list of sitemaps to retrieve a list of urls. If a url is
+given without the sitemap or sitemap index, the provider first looks for a `{url}/sitemap_index.xml` to find a
+set of sitemap files.  If no index is found, it defaults to using `{url}/sitemap.xml`.
 
 * See http://www.sitemaps.org/ for information on how to create a sitemap.
 * See [DpnXmlSitemapBundle](https://github.com/bjo3rnf/DpnXmlSitemapBundle) for creating a sitemap with Symfony2.
@@ -81,19 +81,11 @@ To enable the sitemap provider, configure it in your `config.yml`:
 ```yaml
 zenstruck_cache:
     sitemap_provider:
-        hosts:
-            - http://www.example.com
-```
+        sitemaps:
+            - http://example.com/sitemap.xml # detects if sitemap or sitemap index and act accordingly
+            - http://example.com/en/sitemap.xml # same as above
+            - http://www.example.com # trys http://example.com/sitemap_index.xml and http://example.com/sitemap.xml
 
-or for multiple hosts:
-
-```yaml
-zenstruck_cache:
-    sitemap_provider:
-        hosts:
-            - http://www.example.com
-            - http://www.example.ch
-            - http://www.example.net
 ```
 
 ## Add a Custom URL Provider
@@ -144,5 +136,5 @@ zenstruck_cache:
 
     sitemap_provider:
         enabled:              false
-        hosts:                []
+        sitemaps:             []
 ```

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -28,7 +28,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('sitemap_provider')
                     ->canBeEnabled()
                     ->children()
-                        ->arrayNode('hosts')
+                        ->arrayNode('sitemaps')
                             ->requiresAtLeastOneElement()
                             ->prototype('scalar')->end()
                         ->end()

--- a/src/DependencyInjection/ZenstruckCacheExtension.php
+++ b/src/DependencyInjection/ZenstruckCacheExtension.php
@@ -29,7 +29,7 @@ class ZenstruckCacheExtension extends ConfigurableExtension
         $this->configureMessageFactory($mergedConfig['message_factory'], $container);
 
         if ($mergedConfig['sitemap_provider']['enabled']) {
-            $container->setParameter('zenstruck_cache.sitemap_provider.hosts', $mergedConfig['sitemap_provider']['hosts']);
+            $container->setParameter('zenstruck_cache.sitemap_provider.sitemaps', $mergedConfig['sitemap_provider']['sitemaps']);
             $loader->load('sitemap_provider.xml');
         }
     }

--- a/src/Resources/config/sitemap_provider.xml
+++ b/src/Resources/config/sitemap_provider.xml
@@ -10,7 +10,7 @@
 
     <services>
         <service id="zenstruck_cache.sitemap_provider" class="%zenstruck_cache.sitemap_provider.class%" public="false">
-            <argument>%zenstruck_cache.sitemap_provider.hosts%</argument>
+            <argument>%zenstruck_cache.sitemap_provider.sitemaps%</argument>
             <argument type="service" id="zenstruck_cache.http_adapter" />
             <argument type="service" id="zenstruck_cache.message_factory" />
             <tag name="zenstruck_cache.url_provider" />

--- a/tests/DependencyInjection/ZenstruckCacheExtensionTest.php
+++ b/tests/DependencyInjection/ZenstruckCacheExtensionTest.php
@@ -112,12 +112,12 @@ class ZenstruckCacheExtensionTest extends AbstractExtensionTestCase
         $this->compile();
     }
 
-    public function testWithSitemapProviderHosts()
+    public function testWithSitemapProviderSitemaps()
     {
         $this->load([
             'http_adapter' => 'foo',
             'message_factory' => 'bar',
-            'sitemap_provider' => ['hosts' => ['http://www.example.com']],
+            'sitemap_provider' => ['sitemaps' => ['http://www.example.com']],
         ]);
         $this->compile();
 
@@ -127,12 +127,12 @@ class ZenstruckCacheExtensionTest extends AbstractExtensionTestCase
     /**
      * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      */
-    public function testWithEmptySitemapProviderHosts()
+    public function testWithEmptySitemapProviderSitemaps()
     {
         $this->load([
             'http_adapter' => 'foo',
             'message_factory' => 'bar',
-            'sitemap_provider' => ['hosts' => []],
+            'sitemap_provider' => ['sitemaps' => []],
         ]);
         $this->compile();
     }

--- a/tests/Url/SitemapUrlProviderTest.php
+++ b/tests/Url/SitemapUrlProviderTest.php
@@ -13,7 +13,7 @@ class SitemapUrlProviderTest extends TestCase
     /**
      * @dataProvider fetchProvider
      */
-    public function testGetUrls(array $responses, $urlCount, array $urls)
+    public function testGetUrls(array $sitemaps, array $responses, $urlCount, array $urls)
     {
         $httpAdapter = $this->mockHttpAdapter();
         $messageFactory = $this->mockMessageFactory();
@@ -34,7 +34,7 @@ class SitemapUrlProviderTest extends TestCase
                 ->willReturn($response[1]);
         }
 
-        $provider = new SitemapUrlProvider([''], $httpAdapter, $messageFactory);
+        $provider = new SitemapUrlProvider($sitemaps, $httpAdapter, $messageFactory);
 
         $this->assertCount($urlCount, $provider->getUrls());
         $this->assertSame($urls, $provider->getUrls());
@@ -45,32 +45,36 @@ class SitemapUrlProviderTest extends TestCase
     {
         return [
             [
+                ['http://ex.com'],
                 [
-                    ['/sitemap_index.xml', $this->mockResponse('', 404)],
-                    ['/sitemap.xml', $this->mockResponse('<?xml version="1.0" encoding="UTF-8"?><urlset><url><loc>http://foo.com</loc></url><url><loc>http://bar.com</loc></url></urlset>', 200)],
+                    ['http://ex.com/sitemap_index.xml', $this->mockResponse('', 404)],
+                    ['http://ex.com/sitemap.xml', $this->mockResponse('<?xml version="1.0" encoding="UTF-8"?><urlset><url><loc>http://foo.com</loc></url><url><loc>http://bar.com</loc></url></urlset>', 200)],
                 ],
                 2,
                 ['http://foo.com', 'http://bar.com'],
             ],
             [
+                ['http://ex.com'],
                 [
-                    ['/sitemap_index.xml', $this->mockResponse('', 404)],
-                    ['/sitemap.xml', $this->mockResponse('<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"><url><loc>http://foo.com</loc></url><url><loc>http://bar.com</loc></url></urlset>', 200)],
+                    ['http://ex.com/sitemap_index.xml', $this->mockResponse('', 404)],
+                    ['http://ex.com/sitemap.xml', $this->mockResponse('<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"><url><loc>http://foo.com</loc></url><url><loc>http://bar.com</loc></url></urlset>', 200)],
                 ],
                 2,
                 ['http://foo.com', 'http://bar.com'],
             ],
             [
+                ['http://ex.com'],
                 [
-                    ['/sitemap_index.xml', $this->mockResponse('<?xml version="1.0" encoding="UTF-8"?><sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><sitemap><loc>http://baz.com/sitemap.xml</loc></sitemap></sitemapindex>', 200)],
+                    ['http://ex.com/sitemap_index.xml', $this->mockResponse('<?xml version="1.0" encoding="UTF-8"?><sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><sitemap><loc>http://baz.com/sitemap.xml</loc></sitemap></sitemapindex>', 200)],
                     ['http://baz.com/sitemap.xml', $this->mockResponse('<?xml version="1.0" encoding="UTF-8"?><urlset><url><loc>http://foo.com</loc></url><url><loc>http://bar.com</loc></url></urlset>', 200)],
                 ],
                 2,
                 ['http://foo.com', 'http://bar.com'],
             ],
             [
+                ['http://ex.com'],
                 [
-                    ['/sitemap_index.xml', $this->mockResponse('<?xml version="1.0" encoding="UTF-8"?><sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><sitemap><loc>http://baz.com/sitemap1.xml</loc></sitemap><sitemap><loc>http://baz.com/sitemap2.xml</loc></sitemap></sitemapindex>', 200)],
+                    ['http://ex.com/sitemap_index.xml', $this->mockResponse('<?xml version="1.0" encoding="UTF-8"?><sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><sitemap><loc>http://baz.com/sitemap1.xml</loc></sitemap><sitemap><loc>http://baz.com/sitemap2.xml</loc></sitemap></sitemapindex>', 200)],
                     ['http://baz.com/sitemap1.xml', $this->mockResponse('<?xml version="1.0" encoding="UTF-8"?><urlset><url><loc>http://foo.com</loc></url><url><loc>http://bar.com</loc></url></urlset>', 200)],
                     ['http://baz.com/sitemap2.xml', $this->mockResponse('<?xml version="1.0" encoding="UTF-8"?><urlset><url><loc>http://foo.com</loc></url><url><loc>http://bar.com</loc></url></urlset>', 200)],
                 ],
@@ -78,12 +82,33 @@ class SitemapUrlProviderTest extends TestCase
                 ['http://foo.com', 'http://bar.com', 'http://foo.com', 'http://bar.com'],
             ],
             [
+                ['http://ex.com'],
                 [
-                    ['/sitemap_index.xml', $this->mockResponse('', 404)],
-                    ['/sitemap.xml', $this->mockResponse('', 404)],
+                    ['http://ex.com/sitemap_index.xml', $this->mockResponse('', 404)],
+                    ['http://ex.com/sitemap.xml', $this->mockResponse('', 404)],
                 ],
                 0,
                 [],
+            ],
+            [
+                ['http://ex.com/sitemap_index.xml', 'http://ex.com/sitemap.xml'],
+                [
+                    ['http://ex.com/sitemap_index.xml', $this->mockResponse('', 404)],
+                    ['http://ex.com/sitemap.xml', $this->mockResponse('<?xml version="1.0" encoding="UTF-8"?><urlset><url><loc>http://foo.com</loc></url><url><loc>http://bar.com</loc></url></urlset>', 200)],
+                ],
+                2,
+                ['http://foo.com', 'http://bar.com'],
+            ],
+            [
+                ['http://ex.com/sitemap_index1.xml'],
+                [
+                    ['http://ex.com/sitemap_index1.xml', $this->mockResponse('<?xml version="1.0" encoding="UTF-8"?><sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><sitemap><loc>http://ex.com/sitemap_index2.xml</loc></sitemap><sitemap><loc>http://baz.com/sitemap1.xml</loc></sitemap></sitemapindex>', 200)],
+                    ['http://ex.com/sitemap_index2.xml', $this->mockResponse('<?xml version="1.0" encoding="UTF-8"?><sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><sitemap><loc>http://baz.com/sitemap2.xml</loc></sitemap></sitemapindex>', 200)],
+                    ['http://baz.com/sitemap2.xml', $this->mockResponse('<?xml version="1.0" encoding="UTF-8"?><urlset><url><loc>http://foo.com</loc></url><url><loc>http://bar.com</loc></url></urlset>', 200)],
+                    ['http://baz.com/sitemap1.xml', $this->mockResponse('<?xml version="1.0" encoding="UTF-8"?><urlset><url><loc>http://foo.com</loc></url><url><loc>http://bar.com</loc></url></urlset>', 200)],
+                ],
+                4,
+                ['http://foo.com', 'http://bar.com', 'http://foo.com', 'http://bar.com'],
             ],
         ];
     }


### PR DESCRIPTION
- recursively parse sitemap indexes
- allow specifying sitemap and sitemap indexes in url
- if url does not contain file, try `sitemap_index.xml` and `sitemap.xml`
- change config key `zenstruck_cache.sitemap_provider.hosts` to `zenstruck_cache.sitemap_provider.sitemaps`